### PR TITLE
Isolate directory names when extracting

### DIFF
--- a/actions/extract_files/src/main.sh
+++ b/actions/extract_files/src/main.sh
@@ -15,7 +15,9 @@ create_output_dir() {
     local dir_name=$(dirname "$relative_path")
 
     if [[ "$ROBOTO_PARAM_ISOLATE_EXTRACTION" == "True" ]]; then
-        output_dir="$output_dir/$dir_name/$base_name"
+        # Strip the extension and append _dir
+        local base_name_no_ext="${base_name%.*}"
+        output_dir="$output_dir/$dir_name/${base_name_no_ext}_dir"
     else
         output_dir="$output_dir/$dir_name"
     fi


### PR DESCRIPTION
**Problem:** This extract files action has caused some headaches when trying to migrate to the new file tree structure in prod. 

**Solution:** Files and directories can't have the same name at the same level in the tree, just like a normal file system. This update makes sure we're not naming the folder the same thing as our file. 

**Testing:** Tested code snippet in terminal to verify extension is being removed and replaced with "_dir". 